### PR TITLE
correct errors in OpenAPI urls

### DIFF
--- a/candidate-standard/clause_7_core.adoc
+++ b/candidate-standard/clause_7_core.adoc
@@ -174,6 +174,6 @@ The EDR API standard has identified an initial set of common `queryTypes` to imp
 |Locations | /locations
 |Postion | /position
 |Trajectory | /trajectory
-|Instance | /instance
+|Instances | /instances
 |===
 

--- a/candidate-standard/openapi/EDR_OpenAPI.json
+++ b/candidate-standard/openapi/EDR_OpenAPI.json
@@ -1174,7 +1174,7 @@
         }
       }
     },
-    "/collections/{collectionId}/instance": {
+    "/collections/{collectionId}/instances": {
       "get": {
         "tags": [
           "Collection metadata"
@@ -1224,7 +1224,7 @@
         }
       ]
     },
-    "/collections/{collectionId}/instance/{instanceId}/position": {
+    "/collections/{collectionId}/instances/{instanceId}/position": {
       "get": {
         "tags": [
           "Instance data queries"
@@ -1328,7 +1328,7 @@
         }
       }
     },
-    "/collections/{collectionId}/instance/{instanceId}/radius": {
+    "/collections/{collectionId}/instances/{instanceId}/radius": {
       "get": {
         "tags": [
           "Instance data queries"
@@ -1438,7 +1438,7 @@
         }
       }
     },
-    "/collections/{collectionId}/instance/{instanceId}/area": {
+    "/collections/{collectionId}/instances/{instanceId}/area": {
       "get": {
         "tags": [
           "Instance data queries"
@@ -1548,7 +1548,7 @@
         }
       }
     },
-    "/collections/{collectionId}/instance/{instanceId}/cube": {
+    "/collections/{collectionId}/instances/{instanceId}/cube": {
       "get": {
         "tags": [
           "Instance data queries"
@@ -1664,7 +1664,7 @@
         }
       }
     },
-    "/collections/{collectionId}/instance/{instanceId}/trajectory": {
+    "/collections/{collectionId}/instances/{instanceId}/trajectory": {
       "get": {
         "tags": [
           "Instance data queries"
@@ -1762,7 +1762,7 @@
         }
       }
     },
-    "/collections/{collectionId}/instance/{instanceId}/corridor": {
+    "/collections/{collectionId}/instances/{instanceId}/corridor": {
       "get": {
         "tags": [
           "Instance data queries"
@@ -1872,7 +1872,7 @@
         }
       }
     },
-    "/collections/{collectionId}/instance/{instanceId}/locations/{locID}": {
+    "/collections/{collectionId}/instances/{instanceId}/locations/{locID}": {
       "get": {
         "tags": [
           "Instance data queries"
@@ -2045,7 +2045,7 @@
         }
       }
     },
-    "/collections/{collectionId}/instance/{instanceId}/locations": {
+    "/collections/{collectionId}/instances/{instanceId}/locations": {
       "get": {
         "tags": [
           "Instance metadata"

--- a/candidate-standard/openapi/EDR_OpenAPI.yaml
+++ b/candidate-standard/openapi/EDR_OpenAPI.yaml
@@ -686,7 +686,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{collectionId}/instance':
+  '/collections/{collectionId}/instances':
     get:
       tags:
         - Collection metadata
@@ -715,7 +715,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/collectionId'
       - $ref: '#/components/parameters/outputFormat'
-  '/collections/{collectionId}/instance/{instanceId}/position':
+  '/collections/{collectionId}/instances/{instanceId}/position':
     get:
       tags:
         - Instance data queries
@@ -774,7 +774,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{collectionId}/instance/{instanceId}/radius':
+  '/collections/{collectionId}/instances/{instanceId}/radius':
     get:
       tags:
         - Instance data queries
@@ -835,7 +835,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{collectionId}/instance/{instanceId}/area':
+  '/collections/{collectionId}/instances/{instanceId}/area':
     get:
       tags:
         - Instance data queries
@@ -897,7 +897,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{collectionId}/instance/{instanceId}/cube':
+  '/collections/{collectionId}/instances/{instanceId}/cube':
     get:
       tags:
         - Instance data queries
@@ -960,7 +960,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{collectionId}/instance/{instanceId}/trajectory':
+  '/collections/{collectionId}/instances/{instanceId}/trajectory':
     get:
       tags:
         - Instance data queries
@@ -1017,7 +1017,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{collectionId}/instance/{instanceId}/corridor':
+  '/collections/{collectionId}/instances/{instanceId}/corridor':
     get:
       tags:
         - Instance data queries
@@ -1078,7 +1078,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{collectionId}/instance/{instanceId}/locations/{locID}':
+  '/collections/{collectionId}/instances/{instanceId}/locations/{locID}':
     get:
       tags:
         - Instance data queries
@@ -1179,7 +1179,7 @@ paths:
             text/html:
               schema:
                 type: string
-  '/collections/{collectionId}/instance/{instanceId}/locations':
+  '/collections/{collectionId}/instances/{instanceId}/locations':
     get:
       tags:
         - Instance metadata


### PR DESCRIPTION
Correct the OpenAPI urls for instance queries, changes the path definitions from /instance to /instances