### PR TITLE
Fix error in coverageJSON schema

### DIFF
--- a/candidate-standard/openapi/schemas/coverageJSON.json
+++ b/candidate-standard/openapi/schemas/coverageJSON.json
@@ -251,7 +251,7 @@
             "description": "Parameter data values",
             "type": "array",
             "items": {
-              "oneOf": "number string"
+              "oneOf": ["number", "string"]
             }
           }
         },


### PR DESCRIPTION
Fix error in the coverageJSON schema which was preventing the OpenAPI definition working with ReDoc   